### PR TITLE
Reboot Server Feature for ComputeService

### DIFF
--- a/OpenStack/OpenStack/Compute/ComputeServiceClient.cs
+++ b/OpenStack/OpenStack/Compute/ComputeServiceClient.cs
@@ -221,6 +221,16 @@ namespace OpenStack.Compute
             return await client.CreateServer(name, imageId, flavorId, networkId, keyName, securityGroups);
         }
 
+		/// <inheritdoc/>
+		public async Task RebootServer(string serverId, string rebootType)
+		{
+			serverId.AssertIsNotNullOrEmpty("serverId", "Cannot reboot a server with a null or empty id.");
+			rebootType.AssertIsNotNullOrEmpty("rebootType", "Cannot reboot a server with an null or empty reboot type.");
+
+			var client = this.GetPocoClient();
+			await client.RebootServer(serverId, rebootType);
+		}
+
         /// <summary>
         /// Gets a client to interact with the remote OpenStack instance.
         /// </summary>

--- a/OpenStack/OpenStack/Compute/ComputeServicePocoClient.cs
+++ b/OpenStack/OpenStack/Compute/ComputeServicePocoClient.cs
@@ -215,6 +215,19 @@ namespace OpenStack.Compute
             return metadata;
         }
 
+		/// <inheritdoc/>
+		/// TODO: Add Progress, see CreateServer
+		public async Task RebootServer(string serverId, string rebootType)
+		{
+			var client = this.GetRestClient();
+			var resp = await client.RebootServer(serverId, rebootType);
+
+			if (resp.StatusCode != HttpStatusCode.Accepted && resp.StatusCode != HttpStatusCode.OK)
+			{
+				throw new InvalidOperationException(string.Format("Failed to reboot compute server. The remote server returned the following status code: '{0}'.", resp.StatusCode));
+			}
+		}
+
         /// <inheritdoc/>
         public async Task DeleteServer(string serverId)
         {

--- a/OpenStack/OpenStack/Compute/ComputeServiceRestClient.cs
+++ b/OpenStack/OpenStack/Compute/ComputeServiceRestClient.cs
@@ -225,6 +225,21 @@ namespace OpenStack.Compute
             return await client.SendAsync();
         }
 
+		/// <inheritdoc/>
+		public async Task<IHttpResponseAbstraction> RebootServer(string serverId, string rebootType)
+		{
+			var client = this.GetHttpClient(this.Context);
+
+			client.Uri = CreateRequestUri(this.Context.PublicEndpoint, ServersUrlMoniker, serverId, ActionUrlMoniker);
+			client.Method = HttpMethod.Post;
+
+			var requestBody = this.GenerateRebootServerRequestBody(rebootType);
+			client.Content = requestBody.ConvertToStream();
+			client.ContentType = "application/json";
+
+			return await client.SendAsync();
+		}
+
         /// <inheritdoc/>
         internal async Task<IHttpResponseAbstraction> DeleteItemMetadata(string itemType, string itemId, string key)
         {
@@ -306,6 +321,21 @@ namespace OpenStack.Compute
             body.server = server;
             return JToken.FromObject(body).ToString();
         }
+
+		/// <summary>
+		/// Generates a request body for rebooting a server.
+		/// </summary>
+		/// <param name="rebootType">Can either be SOFT or HARD reboot.</param>
+		/// <returns>A json encoded request body.</returns>
+		internal string GenerateRebootServerRequestBody(string rebootType)
+		{
+			dynamic reboot = new System.Dynamic.ExpandoObject();
+			reboot.type = rebootType;
+				
+			dynamic body = new System.Dynamic.ExpandoObject();
+			body.reboot = reboot;
+			return JToken.FromObject(body).ToString();
+		}
 
         /// <summary>
         /// Generates a request body for creating compute servers.

--- a/OpenStack/OpenStack/Compute/IComputeServiceClient.cs
+++ b/OpenStack/OpenStack/Compute/IComputeServiceClient.cs
@@ -92,6 +92,14 @@ namespace OpenStack.Compute
         /// <returns>A server object.</returns>
         Task<ComputeServer> CreateServer(string name, string imageId, string flavorId, string networkId, IEnumerable<string> securityGroups);
 
+		/// <summary>
+		/// Reboot a server on the remote OpenStack instance.
+		/// </summary>
+		/// <param name="serverId">The id of the server.</param>
+		/// <param name="rebootType">Either hard or soft reboot.</param>
+		/// <returns>A server object.</returns>
+		Task RebootServer(string serverId, string rebootType);
+
         /// <summary>
         /// Deletes a server from the remote OpenStack instance.
         /// </summary>

--- a/OpenStack/OpenStack/Compute/IComputeServicePocoClient.cs
+++ b/OpenStack/OpenStack/Compute/IComputeServicePocoClient.cs
@@ -69,6 +69,15 @@ namespace OpenStack.Compute
         /// <returns>A server object.</returns>
         Task<ComputeServer> CreateServer(string name, string imageId, string flavorId, string networkId, string keyName, IEnumerable<string> securityGroups);
 
+		/// <summary>
+		/// Reboot a server on the remote OpenStack instance.
+		/// </summary>
+		/// <param name="serverId">The id of the server.</param>
+		/// <param name="rebootType">Either hard or soft reboot.</param>
+		/// <returns>A server object.</returns>
+		Task RebootServer(string serverId, string rebootType);
+
+
         /// <summary>
         /// Deletes the server with the given id from the remote OpenStack instance.
         /// </summary>

--- a/OpenStack/OpenStack/Compute/IComputeServiceRestClient.cs
+++ b/OpenStack/OpenStack/Compute/IComputeServiceRestClient.cs
@@ -95,6 +95,15 @@ namespace OpenStack.Compute
         /// <returns>An HTTP response from the remote server.</returns>
         Task<IHttpResponseAbstraction> CreateServer(string name, string imageId, string flavorId, string networkId, string keyName, IEnumerable<string> securityGroups);
 
+		/// <summary>
+		/// Reboot a server on the remote OpenStack instance.
+		/// </summary>
+		/// <param name="serverId">The id of the server.</param>
+		/// <param name="rebootType">Type of the reboot (hard or soft).</param>
+		/// <returns>An HTTP response from the remote server.</returns>
+		Task<IHttpResponseAbstraction> RebootServer(string serverId, string rebootType);
+
+
         /// <summary>
         /// Gets a list of servers from the remote OpenStack instance.
         /// </summary>


### PR DESCRIPTION
Hey there,

I added reboot functionality to the compute client of the SDK. Even though it took me a while to get into the architecture of the code, I still don't complete understand the testing architecture. As far as I understand you guys kind of mock the api responses to not depend on a real OpenStack test environment . Can you maybe explain in a few words what the best practice here is, so I can add tests for further stuff. 

Thanks.

Kevin
